### PR TITLE
fix: Redis server version check

### DIFF
--- a/affinidi-messaging-mediator/src/database/handlers.rs
+++ b/affinidi-messaging-mediator/src/database/handlers.rs
@@ -170,10 +170,14 @@ async fn _check_server_version(database: &DatabaseHandler) -> Result<String, Med
             .zip(required_version_parts.iter())
             .all(|(server, required)| {
                 if is_higher {
+                    // if major is higher, no need to check for next
                     true
                 } else {
-                    is_higher = *server >= *required;
-                    is_higher
+                    if *server > *required {
+                        is_higher = true
+                    }
+                    let result = *server >= *required;
+                    result
                 }
             });
 


### PR DESCRIPTION
Update Redis server version check to recognize all Major/Minor versions. 
eg: `version.starts_with()` does not work when version `7.4.1` does not start with `REDIS_VERSION` `7.1`.