### PR TITLE
feat: change loogging to json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ tracing = { version = "0.1", features = [
     "max_level_debug",
     "release_max_level_info",
 ] }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 tracing-test = "0.2"
 tui-input = "0.11.0"
 tui-logger = { version = "0.14", features = ["tracing-support"] }

--- a/affinidi-messaging-mediator/src/server.rs
+++ b/affinidi-messaging-mediator/src/server.rs
@@ -21,7 +21,7 @@ pub async fn start() {
     let ansi = env::var("LOCAL").is_ok();
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer().with_ansi(ansi))
+        .with(tracing_subscriber::fmt::layer().with_ansi(ansi).json())
         .init();
 
     if ansi {

--- a/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -22,33 +22,37 @@ pub async fn statistics(database: DatabaseHandler) -> Result<(), MediatorError> 
             interval.tick().await;
             let stats = database.get_db_metadata().await?;
             let delta = stats.delta(&previous_stats);
-            info!(event_type="UpdateStats",
-                  received_bytes=stats.received_bytes,
-                  sent_bytes=stats.sent_bytes,
-                  deleted_bytes=stats.deleted_bytes,
-                  received_count=stats.received_count,
-                  sent_count=stats.sent_count,
-                  deleted_count=stats.deleted_count,
-                  websocket_open=stats.websocket_open,
-                  websocket_close=stats.websocket_close,
-                  sessions_created=stats.sessions_created,
-                  sessions_success=stats.sessions_success,
-                  oob_invites_created=stats.oob_invites_created,
-                  oob_invites_claimed=stats.oob_invites_claimed);
+            info!(
+                event_type = "UpdateStats",
+                received_bytes = stats.received_bytes,
+                sent_bytes = stats.sent_bytes,
+                deleted_bytes = stats.deleted_bytes,
+                received_count = stats.received_count,
+                sent_count = stats.sent_count,
+                deleted_count = stats.deleted_count,
+                websocket_open = stats.websocket_open,
+                websocket_close = stats.websocket_close,
+                sessions_created = stats.sessions_created,
+                sessions_success = stats.sessions_success,
+                oob_invites_created = stats.oob_invites_created,
+                oob_invites_claimed = stats.oob_invites_claimed
+            );
 
-            info!(event_type="UpdateDeltaStats",
-                  received_bytes=delta.received_bytes,
-                  sent_bytes=delta.sent_bytes,
-                  deleted_bytes=delta.deleted_bytes,
-                  received_count=delta.received_count,
-                  sent_count=delta.sent_count,
-                  deleted_count=delta.deleted_count,
-                  websocket_open=delta.websocket_open,
-                  websocket_close=delta.websocket_close,
-                  sessions_created=delta.sessions_created,
-                  sessions_success=delta.sessions_success,
-                  oob_invites_created=delta.oob_invites_created,
-                  oob_invites_claimed=delta.oob_invites_claimed);
+            info!(
+                event_type = "UpdateDeltaStats",
+                received_bytes = delta.received_bytes,
+                sent_bytes = delta.sent_bytes,
+                deleted_bytes = delta.deleted_bytes,
+                received_count = delta.received_count,
+                sent_count = delta.sent_count,
+                deleted_count = delta.deleted_count,
+                websocket_open = delta.websocket_open,
+                websocket_close = delta.websocket_close,
+                sessions_created = delta.sessions_created,
+                sessions_success = delta.sessions_success,
+                oob_invites_created = delta.oob_invites_created,
+                oob_invites_claimed = delta.oob_invites_claimed
+            );
 
             previous_stats = stats;
         }

--- a/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -21,8 +21,34 @@ pub async fn statistics(database: DatabaseHandler) -> Result<(), MediatorError> 
         loop {
             interval.tick().await;
             let stats = database.get_db_metadata().await?;
-            info!("Statistics: {}", stats);
-            info!("Delta: {}", stats.delta(&previous_stats));
+            let delta = stats.delta(&previous_stats);
+            info!(event_type="UpdateStats",
+                  received_bytes=stats.received_bytes,
+                  sent_bytes=stats.sent_bytes,
+                  deleted_bytes=stats.deleted_bytes,
+                  received_count=stats.received_count,
+                  sent_count=stats.sent_count,
+                  deleted_count=stats.deleted_count,
+                  websocket_open=stats.websocket_open,
+                  websocket_close=stats.websocket_close,
+                  sessions_created=stats.sessions_created,
+                  sessions_success=stats.sessions_success,
+                  oob_invites_created=stats.oob_invites_created,
+                  oob_invites_claimed=stats.oob_invites_claimed);
+
+            info!(event_type="UpdateDeltaStats",
+                  received_bytes=delta.received_bytes,
+                  sent_bytes=delta.sent_bytes,
+                  deleted_bytes=delta.deleted_bytes,
+                  received_count=delta.received_count,
+                  sent_count=delta.sent_count,
+                  deleted_count=delta.deleted_count,
+                  websocket_open=delta.websocket_open,
+                  websocket_close=delta.websocket_close,
+                  sessions_created=delta.sessions_created,
+                  sessions_success=delta.sessions_success,
+                  oob_invites_created=delta.oob_invites_created,
+                  oob_invites_claimed=delta.oob_invites_claimed);
 
             previous_stats = stats;
         }


### PR DESCRIPTION
This change puts json logging in place. 
A few sample lines are as below:
```
{"timestamp":"2025-01-15T14:47:51.021985Z","level":"INFO","fields":{"message":"Log level set to (info)"},"target":"affinidi_messaging_mediator::common::config"}

{"timestamp":"2025-01-15T14:47:51.033678Z","level":"INFO","fields":{"message":"Loading secrets method(file) path(./conf/secrets.json)"},"target":"affinidi_messaging_mediator::common::config"}

{"timestamp":"2025-01-15T14:47:51.034917Z","level":"INFO","fields":{"message":"Configuration settings parsed successfully.\nConfig {\n    log_level: LevelFilter::INFO,\n    listen_address: \"0.0.0.0:7037\",\n    mediator_did: \"did:web:localhost%3A7037:mediator:v1:.well-known\",\n    admin_did: \"did:peer:2.Vz6MkkvDN4qvj2HNof4vYfrQX1hhPe4Bp1zEfwrVikT4URHEo.EzQ3shcs6BSFpY6RRaCmyvJTmVpbAugNAGr7Fp139tdLTPNkSC\",\n    mediator_did_doc: \"Hidden\",\n    database: DatabaseConfig {\n        functions_file: \"./conf/atm-functions.lua\",\n        database_url: \"redis://@localhost:6379\",\n        database_pool_size: 10,\n        database_timeout: 2,\n    },\n    streaming_enabled?: true,\n    streaming_uuid: \"Win-PF202VRG\",\n    DID Resolver config: ClientConfig {\n        service_address: None,\n        cache_capacity: 1000,\n        cache_ttl: 300,\n        network_timeout: 5s,\n        network_cache_limit_count: 100,\n        max_did_parts: 12,\n        max_did_size_in_kb: 1.0,\n    },\n    api_prefix: \"/mediator/v1/\",\n    security: SecurityConfig {\n        acl_mode: explicit_deny,\n        mediator_secrets: \"(2) secrets loaded\",\n        use_ssl: false,\n        ssl_certificate_file: \"conf/keys/end.cert\",\n        ssl_key_file: \"conf/keys/end.key\",\n        jwt_encoding_key?: \"<hidden>\",\n        jwt_decoding_key?: \"<hidden>\",\n        jwt_access_expiry: 900,\n        jwt_refresh_expiry: 86400,\n        cors_allow_origin: CorsLayer {\n            allow_credentials: No,\n            allow_headers: Const(\n                Some(\n                    \"authorization,content-type\",\n                ),\n            ),\n            allow_methods: Const(\n                Some(\n                    \"GET,POST,OPTIONS,DELETE,PATCH,PUT\",\n                ),\n            ),\n            allow_origin: Const(\n                \"*\",\n            ),\n            allow_private_network: No,\n            expose_headers: Const(\n                None,\n            ),\n            max_age: Exact(\n                None,\n            ),\n            vary: Vary(\n                [\n                    \"origin\",\n                    \"access-control-request-method\",\n                    \"access-control-request-headers\",\n                ],\n            ),\n        },\n    },\n    processor Forwarding: ForwardingConfig {\n        enabled: true,\n        future_time_limit: 86400,\n    },\n    Limits: LimitsConfig {\n        attachments_max_count: 20,\n        crypto_operations_per_message: 1000,\n        deleted_messages: 100,\n        forward_task_queue: 50000,\n        http_size: 10485760,\n        listed_messages: 100,\n        local_max_acl: 1000,\n        message_expiry_minutes: 10080,\n        message_size: 1048576,\n        queued_messages: 100,\n        to_keys_per_recipient: 100,\n        to_recipients: 100,\n        ws_size: 10485760,\n    },\n}"},"target":"affinidi_messaging_mediator::common::config"}

{"timestamp":"2025-01-15T14:47:51.079729Z","level":"INFO","fields":{"message":"Database ping ok! Expected (PONG) received (PONG)"},"target":"affinidi_messaging_mediator::database::handlers"}

{"timestamp":"2025-01-15T14:47:51.083867Z","level":"INFO","fields":{"message":"Redis version is compatible: 7.4.2"},"target":"affinidi_messaging_mediator::database::handlers"}

{"timestamp":"2025-01-15T14:47:51.093985Z","level":"INFO","fields":{"message":"Loaded LUA scripts into the database from file: ./conf/atm-functions.lua"},"target":"affinidi_messaging_mediator::database::handlers"}

{"timestamp":"2025-01-15T14:47:51.101784Z","level":"INFO","fields":{"message":"Admin account successfully setup: did:peer:2.Vz6MkkvDN4qvj2HNof4vYfrQX1hhPe4Bp1zEfwrVikT4URHEo.EzQ3shcs6BSFpY6RRaCmyvJTmVpbAugNAGr7Fp139tdLTPNkSC"},"target":"affinidi_messaging_mediator::database::admin_accounts"}

{"timestamp":"2025-01-15T14:47:51.105859Z","level":"WARN","fields":{"message":"**** WARNING: Running without SSL/TLS ****"},"target":"affinidi_messaging_mediator::server"}

{"timestamp":"2025-01-15T14:47:51.107670Z","level":"INFO","fields":{"message":"clean_start_streaming() cleaned 0 sessions"},"target":"affinidi_messaging_mediator::database::streaming","span":{"uuid":"Win-PF202VRG","name":"ws_streaming_task"},"spans":[{"uuid":"Win-PF202VRG","name":"ws_streaming_task"}]}

{"timestamp":"2025-01-15T14:47:51.115237Z","level":"INFO","fields":{"event_type":"UpdateStats","received_bytes":0,"sent_bytes":0,"deleted_bytes":0,"received_count":0,"sent_count":0,"deleted_count":0,"websocket_open":0,"websocket_close":0,"sessions_created":0,"sessions_success":0,"oob_invites_created":0,"oob_invites_claimed":0},"target":"affinidi_messaging_mediator::tasks::statistics","span":{"name":"statistics"},"spans":[{"name":"statistics"}]}

{"timestamp":"2025-01-15T14:47:51.115471Z","level":"INFO","fields":{"event_type":"UpdateDeltaStats","received_bytes":0,"sent_bytes":0,"deleted_bytes":0,"received_count":0,"sent_count":0,"deleted_count":0,"websocket_open":0,"websocket_close":0,"sessions_created":0,"sessions_success":0,"oob_invites_created":0,"oob_invites_claimed":0},"target":"affinidi_messaging_mediator::tasks::statistics","span":{"name":"statistics"},"spans":[{"name":"statistics"}]}

{"timestamp":"2025-01-15T14:47:51.119921Z","level":"INFO","fields":{"message":"Subscribed to channel: CHANNEL:Win-PF202VRG"},"target":"affinidi_messaging_mediator::tasks::websocket_streaming","span":{"name":"_start_pubsub"},"spans":[{"uuid":"Win-PF202VRG","name":"ws_streaming_task"},{"name":"_start_pubsub"}]}

```