### PR TITLE
fix: axum merge used for root api_prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-helpers"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-processor"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-text-client"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '0.8.9'
+version = '0.9.0'
 edition = "2021"
 authors = ["Glenn Gore <glenn@affinidi.com>"]
 description = "Affinidi Messaging"
@@ -22,9 +22,9 @@ license = "Apache-2.0"
 repository = "https://github.com/affinidi/affinidi-messaging"
 
 [workspace.dependencies]
-affinidi-messaging-sdk = { version = "0.8.9", path = "./affinidi-messaging-sdk" }
-affinidi-messaging-didcomm = { version = "0.8.9", path = "./affinidi-messaging-didcomm" }
-affinidi-messaging-mediator = { version = "0.8.9", path = "./affinidi-messaging-mediator" }
+affinidi-messaging-sdk = { version = "0.9.0", path = "./affinidi-messaging-sdk" }
+affinidi-messaging-didcomm = { version = "0.9.0", path = "./affinidi-messaging-didcomm" }
+affinidi-messaging-mediator = { version = "0.9.0", path = "./affinidi-messaging-mediator" }
 affinidi-did-resolver-cache-sdk = { version = "0.2.4", features = ["network"] }
 anyhow = '1.0'
 askar-crypto = "0.3.3"

--- a/affinidi-messaging-mediator/conf/mediator.toml
+++ b/affinidi-messaging-mediator/conf/mediator.toml
@@ -19,7 +19,7 @@ listen_address = "${LISTEN_ADDRESS:0.0.0.0:7037}"
 
 ### api_prefix: API prefix
 ### Default: /mediator/v1/
-api_prefix = "${API_PREFIX:/mediator/v1/}"
+api_prefix = "${API_PREFIX:/}"
 
 ### admin_did: DID of the admin
 ### REQUIRED: DID of the admin

--- a/affinidi-messaging-mediator/conf/mediator.toml
+++ b/affinidi-messaging-mediator/conf/mediator.toml
@@ -19,7 +19,7 @@ listen_address = "${LISTEN_ADDRESS:0.0.0.0:7037}"
 
 ### api_prefix: API prefix
 ### Default: /mediator/v1/
-api_prefix = "${API_PREFIX:/}"
+api_prefix = "${API_PREFIX:/mediator/v1/}"
 
 ### admin_did: DID of the admin
 ### REQUIRED: DID of the admin

--- a/affinidi-messaging-mediator/src/handlers/message_delete.rs
+++ b/affinidi-messaging-mediator/src/handlers/message_delete.rs
@@ -22,7 +22,7 @@ impl GenericDataStruct for ResponseData {}
 
 /// Deletes a specific message from ATM
 /// Returns a list of messages that were deleted
-/// ACL_MODE: Rquires LOCAL access
+/// ACL_MODE: Requires LOCAL access
 pub async fn message_delete_handler(
     session: Session,
     State(state): State<SharedData>,
@@ -39,7 +39,7 @@ pub async fn message_delete_handler(
         if !session.acls.get_local() {
             return Err(MediatorError::ACLDenied("DID does not have LOCAL access".into()).into());
         }
-        
+
         debug!("Deleting ({}) messages", body.message_ids.len());
         if body.message_ids.len() > state.config.limits.deleted_messages {
             return Err(MediatorError::RequestDataError(

--- a/affinidi-messaging-mediator/src/handlers/mod.rs
+++ b/affinidi-messaging-mediator/src/handlers/mod.rs
@@ -69,9 +69,13 @@ pub fn application_routes(api_prefix: &str, shared_data: &SharedData) -> Router 
         );
     }
 
-    Router::new()
-        .nest(api_prefix, app)
-        .with_state(shared_data.to_owned())
+    let mut router = Router::new();
+    router = if api_prefix.is_empty() || api_prefix == "/" {
+        router.merge(app)
+    } else {
+        router.nest(api_prefix, app)
+    };
+    router.with_state(shared_data.to_owned())
 }
 
 pub async fn health_checker_handler(State(state): State<SharedData>) -> impl IntoResponse {

--- a/affinidi-messaging-mediator/src/messages/protocols/routing.rs
+++ b/affinidi-messaging-mediator/src/messages/protocols/routing.rs
@@ -258,7 +258,7 @@ pub(crate) async fn process(
     }]
 }
 */
-fn service_local(
+fn _service_local(
     session: &Session,
     state: &SharedData,
     next: &str,


### PR DESCRIPTION
In the latest version of `axum` `router.nest` shall not be used for empty or `/` paths - `merge` shall be used instead.

More info: https://github.com/tokio-rs/axum/blob/main/axum/src/routing/mod.rs#L205.