### PR TITLE
v0.9.2 release - websocket invalidation/refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Changelog history
 
+## 18th January 2025 (0.9.2)
+
+### Mediator (0.9.2)
+
+* WebSocket connections will now close when the auth session token expires.
+* Logging can be configured to use JSON or not (log_json)
+* JWT_EXPIRY_TOKEN has a minimum of 10 seconds enforced to stop an issue where clients can get stuck in an
+endless refresh loop
+
+### SDK (0.9.2)
+
+* authentication logic will trigger a token refresh if <5 seconds remain on the expiry token (was 10 seconds)
+* Fix: refresh retry logic where there was a lock related bug on authentication refresh tokens
+
 ## 17th January 2025 (0.8.10)
 
 * Fix Axum Path routes for new version. Internal only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -8096,9 +8096,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-helpers"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-processor"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-text-client"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -6026,9 +6026,9 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -6142,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '0.9.1'
+version = '0.9.2'
 edition = "2021"
 authors = ["Glenn Gore <glenn@affinidi.com>"]
 description = "Affinidi Messaging"
@@ -22,9 +22,9 @@ license = "Apache-2.0"
 repository = "https://github.com/affinidi/affinidi-messaging"
 
 [workspace.dependencies]
-affinidi-messaging-sdk = { version = "0.9.1", path = "./affinidi-messaging-sdk" }
-affinidi-messaging-didcomm = { version = "0.9.1", path = "./affinidi-messaging-didcomm" }
-affinidi-messaging-mediator = { version = "0.9.1", path = "./affinidi-messaging-mediator" }
+affinidi-messaging-sdk = { version = "0.9.2", path = "./affinidi-messaging-sdk" }
+affinidi-messaging-didcomm = { version = "0.9.2", path = "./affinidi-messaging-didcomm" }
+affinidi-messaging-mediator = { version = "0.9.2", path = "./affinidi-messaging-mediator" }
 affinidi-did-resolver-cache-sdk = { version = "0.2.4", features = ["network"] }
 anyhow = '1.0'
 askar-crypto = "0.3.3"
@@ -74,7 +74,6 @@ redis = { version = "0.27", features = [
     "tls-rustls-insecure",
 ] }
 deadpool-redis = { version = "0.18", features = ["rt_tokio_1"] }
-
 regex = "1.11"
 reqwest = { version = "0.12", features = ["rustls-tls-manual-roots", "json"] }
 ring = { version = "0.17", features = ["std"] }
@@ -112,4 +111,4 @@ tui-logger = { version = "0.14", features = ["tracing-support"] }
 url = "2.5"
 uuid = { version = "1.12", features = ["v4", "fast-rng"] }
 varint = "0.9"
-semver = "1.0.24"
+semver = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ color-eyre = "0.6"
 console = "0.15"
 criterion = "0.5"
 crossterm = { version = "0.28", features = ["event-stream"] }
-deadpool-redis = { version = "0.18", features = ["rt_tokio_1"] }
 dialoguer = "0.11"
 did-peer = { version = "0.2.4" }
 futures-util = "0.3"
@@ -69,10 +68,13 @@ rcgen = { version = "0.13", default-features = false, features = [
     "aws_lc_rs",
     "pem",
 ] }
+# Redis can only be updated when deadpool-redis supports the new version
 redis = { version = "0.27", features = [
     "tokio-rustls-comp",
     "tls-rustls-insecure",
 ] }
+deadpool-redis = { version = "0.18", features = ["rt_tokio_1"] }
+
 regex = "1.11"
 reqwest = { version = "0.12", features = ["rustls-tls-manual-roots", "json"] }
 ring = { version = "0.17", features = ["std"] }

--- a/affinidi-messaging-mediator/conf/mediator.toml
+++ b/affinidi-messaging-mediator/conf/mediator.toml
@@ -1,6 +1,15 @@
+### Mediator Configuration
+### You can override these settings by setting environment variables
+### Example: export MEDIATOR_DID=did://did:web:localhost%3A7037:mediator:v1:.well-known
+
 ### log_level: trace debug info warn error
 ### default: info
+### NOTE: RUST_LOG environment variable can override this setting
 log_level = "info"
+
+### log_json: If true, log output will be in JSON format
+### default: true
+log_json = "${LOG_JSON:false}"
 
 ### mediator_did: DID of the mediator
 ### REQUIRED: DID of the mediator
@@ -29,7 +38,7 @@ api_prefix = "${API_PREFIX:/mediator/v1/}"
 ### NOTE: It is strongly recommended to NOT use the same DID as the mediator! 
 ###       This causes more use cases where the secrets of the mediator itself can be exposed in administration tasks.
 ### NOTE: You can add additional Mediator admin DIDs after mediator has started by using the Affinidi Mediator admin DIDComm protocol
-admin_did = "${ADMIN_DID:did://did:peer:2.Vz6MkhTiMG5qhSDGj7mnsBh1ENgpV11nmXSYZyiE8EVk3ZWM5.EzQ3shXy6V6WRQgWBMLaPRqbzvj6Bn4u2mxfFap6oD1EQWKuQh}"
+admin_did = "${ADMIN_DID:did://did:peer:2.Vz6MksaHPuhNEewaJTywkDdBWnHWe2xpW6hva2KSkuvKBKys3.EzQ3shX5rNyeLJXqiBoYq9UFGPpi8sSoBqB5VgDS1LA4CyFAZs}"
 
 ### did_web_self_hosted: <DID Document Path> Path to the self-hosted DID Document
 ### Default: None
@@ -137,6 +146,8 @@ jwt_authorization_secret = "${JWT_AUTHORIZATION_SECRET:string://MFECAQEwBQYDK2Vw
 
 ### jwt_access_expiry: Expiry time in seconds for JWT access tokens
 ### Default: 900 (15 Minutes)
+### NOTE: JWT_ACCESS_EXPIRY has a minimum value of 10 seconds, if you try to set below this it will override it to 10
+###       This is due to SDK's needing some time to refresh the token and handle a transaction before triggering a refresh
 jwt_access_expiry = "${JWT_ACCESS_EXPIRY:900}"
 
 ### jwt_refresh_expiry: Expiry time in seconds for JWT refresh tokens

--- a/affinidi-messaging-mediator/src/common/jwt_auth.rs
+++ b/affinidi-messaging-mediator/src/common/jwt_auth.rs
@@ -142,7 +142,7 @@ where
         let did_hash = digest(&did);
 
         // Everything has passed token wise - expensive database operations happen here
-        let saved_session = state
+        let mut saved_session = state
             .database
             .get_session(&session_id, &did)
             .await
@@ -162,6 +162,9 @@ where
             info!("DID({}) is blocked from connecting", did);
             return Err(AuthError::Blocked);
         }
+
+        // Update the expires at time
+        saved_session.expires_at = token_data.claims.exp;
 
         info!(
             "{}: Protected connection accepted from did_hash({})",

--- a/affinidi-messaging-mediator/src/database/session.rs
+++ b/affinidi-messaging-mediator/src/database/session.rs
@@ -61,6 +61,7 @@ pub struct Session {
     pub authenticated: bool,
     pub acls: MediatorACLSet,
     pub account_type: AccountType,
+    pub expires_at: u64,
 }
 
 impl TryFrom<(&str, HashMap<String, String>)> for Session {

--- a/affinidi-messaging-mediator/src/handlers/authenticate.rs
+++ b/affinidi-messaging-mediator/src/handlers/authenticate.rs
@@ -61,6 +61,7 @@ pub async fn authentication_challenge(
         authenticated: false,
         acls: MediatorACLSet::default(), // this will be updated later
         account_type: AccountType::Standard,
+        expires_at: 0,
     };
     let _span = span!(
         Level::DEBUG,
@@ -278,6 +279,8 @@ pub async fn authentication_response(
                 + (state.config.security.jwt_refresh_expiry
                     - state.config.security.jwt_access_expiry)),
         };
+
+        session.expires_at = access_expires_at;
 
         let response = AuthorizationResponse {
             access_token,

--- a/affinidi-messaging-mediator/src/server.rs
+++ b/affinidi-messaging-mediator/src/server.rs
@@ -13,61 +13,42 @@ use std::{env, net::SocketAddr};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::{self, TraceLayer};
 use tracing::{event, Level};
-use tracing_subscriber::{layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter};
 
 pub async fn start() {
-    // setup logging/tracing framework
-    let filter = EnvFilter::from_default_env(); // This can be changed in the config file!
-    let (filter, reload_handle) = reload::Layer::new(filter);
     let ansi = env::var("LOCAL").is_ok();
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(tracing_subscriber::fmt::layer().with_ansi(ansi).json())
-        .init();
 
     if ansi {
-        event!(Level::INFO, "");
-        event!(
-            Level::INFO,
+        println!();
+        println!(
             r#"        db          ad88     ad88  88               88           88  88     88b           d88                       88  88"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"       d88b        d8"      d8"    ""               ""           88  ""     888b         d888                       88  ""                ,d"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"      d8'`8b       88       88                                   88         88`8b       d8'88                       88                    88"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"     d8'  `8b    MM88MMM  MM88MMM  88  8b,dPPYba,   88   ,adPPYb,88  88     88 `8b     d8' 88   ,adPPYba,   ,adPPYb,88  88  ,adPPYYba,  MM88MMM  ,adPPYba,   8b,dPPYba,"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"    d8YaaaaY8b     88       88     88  88P'   `"8a  88  a8"    `Y88  88     88  `8b   d8'  88  a8P_____88  a8"    `Y88  88  ""     `Y8    88    a8"     "8a  88P'   "Y8"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"   d8""""""""8b    88       88     88  88       88  88  8b       88  88     88   `8b d8'   88  8PP"""""""  8b       88  88  ,adPPPPP88    88    8b       d8  88"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#"  d8'        `8b   88       88     88  88       88  88  "8a,   ,d88  88     88    `888'    88  "8b,   ,aa  "8a,   ,d88  88  88,    ,88    88,   "8a,   ,a8"  88"#
         );
-        event!(
-            Level::INFO,
+        println!(
             r#" d8'          `8b  88       88     88  88       88  88   `"8bbdP"Y8  88     88     `8'     88   `"Ybbd8"'   `"8bbdP"Y8  88  `"8bbdP"Y8    "Y888  `"YbbdP"'   88"#
         );
-        event!(Level::INFO, "");
+        println!();
     }
 
-    event!(
-        Level::INFO,
-        "[Loading Affinidi Secure Messaging Mediator configuration]"
-    );
+    println!("[Loading Affinidi Secure Messaging Mediator configuration]");
 
-    let config = init("conf/mediator.toml", Some(reload_handle))
+    let config = init("conf/mediator.toml", ansi)
         .await
         .expect("Couldn't initialize mediator!");
 


### PR DESCRIPTION
## 18th January 2025 (0.9.2)

### Mediator (0.9.2)

* WebSocket connections will now close when the auth session token expires.
* Logging can be configured to use JSON or not (log_json)
* JWT_EXPIRY_TOKEN has a minimum of 10 seconds enforced to stop an issue where clients can get stuck in an
endless refresh loop

### SDK (0.9.2)

* authentication logic will trigger a token refresh if <5 seconds remain on the expiry token (was 10 seconds)
* Fix: refresh retry logic where there was a lock related bug on authentication refresh tokens