### PR TITLE
Release/0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Missing versions on the changelog simply reflect minor deployment changes on our
 
 * Mediator can now handle JSON Object Attachments
 
+### SDK (0.9.6)
+
+* Message Pickup Protocol
+  * live_stream_next() wraps Duration in an Option to be more clear that this is an optional setting
+
 ### Text-Client (0.9.6)
 
 * When sending a message, will detect if message is already wrapped in a forward envelope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,18 @@ Missing versions on the changelog simply reflect minor deployment changes on our
 
 ### SDK (0.9.6)
 
+* ATM Struct derives Clone trait, allowing for a simpler clone of the inner representation
 * Message Pickup Protocol
-  * live_stream_next() wraps Duration in an Option to be more clear that this is an optional setting
+  * FEATURE: live_stream_next() wraps Duration in an Option to be more clear that this is an optional setting
+  * FIX: live_stream_next() properly waits now for next message vs. only fetching from cache
+* Added the ability for a Profile to direct-stream received messages via a channel
+  * Allows for mix and match combo when messages are being sent to the SDK
+  * Application may want direct-receive capability (all messages from all profiles come on a single channel)
+    * Use the WsHandler::DirectMode config option on ATM Configuration
+  * Some Profiles may want cache mode where you can call next() against the cache. across all profiles
+    * Default mode
+  * You may have some tasks that want to stream via a dedicated channel on a per-profile basis
+    * use profile.enable_direct_channel() and profile.disable_direct_channel()
 
 ### Text-Client (0.9.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Missing versions on the changelog simply reflect minor deployment changes on our
 
 ## xx February 2025 (0.9.6)
 
+### All (0.9.6)
+
+* Cleaning up comments and documentation
+
 ### DIDComm Library (0.9.6)
 
 * pack_encrypted will return the forwarded routing_keys from a Service Record
@@ -18,7 +22,8 @@ Missing versions on the changelog simply reflect minor deployment changes on our
 
 ### Text-Client (0.9.6)
 
-* When sending a message, will detect if mesage is already wrapped in a forward envelope
+* When sending a message, will detect if message is already wrapped in a forward envelope
+* Chat Messages properly wrap in the text window making it easier to read.
 
 ## 30th January 2025 (0.9.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Why are there skipped version numbers? Sometimes when deploying via CI/CD Pipeline we find little issues that only affect deployment.
 Missing versions on the changelog simply reflect minor deployment changes on our tooling.
 
-## xx February 2025 (0.9.6)
+## 3rd February 2025 (0.9.6)
 
 ### All (0.9.6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 ## Changelog history
 
-## XX January 2025 (0.9.4)
+Why are there skipped version numbers? Sometimes when deploying via CI/CD Pipeline we find little issues that only affect deployment.
+Missing versions on the changelog simply reflect minor deployment changes on our tooling.
+
+## xx February 2025 (0.9.6)
+
+### DIDComm Library (0.9.6)
+
+* pack_encrypted will return the forwarded routing_keys from a Service Record
+  * Useful for when detecting if message has already been wrapped in a forward/routing wrapper
+
+### Mediator (0.9.6)
+
+* Mediator can now handle JSON Object Attachments
+
+### Text-Client (0.9.6)
+
+* When sending a message, will detect if mesage is already wrapped in a forward envelope
+
+## 30th January 2025 (0.9.4)
 
 ### All (0.9.4)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.97",
+ "syn 2.0.98",
  "which",
 ]
 
@@ -1640,7 +1640,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2074,7 +2074,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2204,14 +2204,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "deadpool"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
@@ -2489,7 +2489,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2567,7 +2567,7 @@ dependencies = [
  "enum-ordinalize 4.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2622,7 +2622,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2642,7 +2642,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2861,7 +2861,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3672,7 +3672,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4293,7 +4293,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static-iref",
- "syn 2.0.97",
+ "syn 2.0.98",
  "thiserror 1.0.69",
 ]
 
@@ -4641,7 +4641,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4734,9 +4734,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -4755,7 +4755,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4775,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -4959,7 +4959,7 @@ checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5113,7 +5113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5194,7 +5194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6169,7 +6169,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6274,7 +6274,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7270,7 +7270,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7289,7 +7289,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2 0.10.8",
- "syn 2.0.97",
+ "syn 2.0.98",
  "thiserror 1.0.69",
 ]
 
@@ -7330,7 +7330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7352,9 +7352,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.97"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dabd04e3b9a8c3c03d5e743f5ef5e1207befc9de704d477f7198cc28049763e"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7396,7 +7396,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7523,7 +7523,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7534,7 +7534,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7659,7 +7659,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7857,7 +7857,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7940,7 +7940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8255,7 +8255,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -8290,7 +8290,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8438,7 +8438,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8449,7 +8449,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8809,7 +8809,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
  "synstructure 0.13.1",
 ]
 
@@ -8840,7 +8840,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8851,7 +8851,7 @@ checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8871,7 +8871,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
  "synstructure 0.13.1",
 ]
 
@@ -8892,7 +8892,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8914,7 +8914,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.97",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "anyhow",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-helpers"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -191,7 +191,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "ring",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "semver",
  "serde",
  "serde_json",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-processor"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -234,7 +234,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "ring",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
  "serde",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-text-client"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1060,7 +1060,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -3324,7 +3324,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -5231,7 +5231,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "socket2",
  "thiserror 2.0.11",
  "tokio",
@@ -5249,7 +5249,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.11",
@@ -5525,7 +5525,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -5675,7 +5675,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5811,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -5899,7 +5899,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -7670,7 +7670,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "tokio",
 ]
 
@@ -7694,7 +7694,7 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -7748,9 +7748,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -7952,9 +7952,9 @@ dependencies = [
 
 [[package]]
 name = "tui-logger"
-version = "0.14.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a5249b5e5df37af5389721794f9839dad0b3f7b92445f24528199acf2f1805"
+checksum = "43bc97ec8f434a88d6a5e05b507553087a21cc188a8bacbce8198e5335a84888"
 dependencies = [
  "chrono",
  "fxhash",
@@ -7980,7 +7980,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.8.5",
- "rustls 0.23.21",
+ "rustls 0.23.22",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.11",
@@ -8302,9 +8302,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd5da49bdf1f30054cfe0b8ce2958b8fbeb67c4d82c8967a598af481bef255c"
+checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8674,9 +8674,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssi",
+ "textwrap",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -426,7 +427,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -512,7 +513,7 @@ checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -1155,7 +1156,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.97",
  "which",
 ]
 
@@ -1639,7 +1640,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2073,7 +2074,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2144,7 +2145,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2177,7 +2178,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2203,7 +2204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2488,7 +2489,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2566,7 +2567,7 @@ dependencies = [
  "enum-ordinalize 4.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2621,7 +2622,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2641,7 +2642,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -2860,7 +2861,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -3517,7 +3518,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -3660,7 +3661,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -3671,7 +3672,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -4292,7 +4293,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static-iref",
- "syn 2.0.96",
+ "syn 2.0.97",
  "thiserror 1.0.69",
 ]
 
@@ -4640,7 +4641,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -4754,7 +4755,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -4958,7 +4959,7 @@ checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -5112,7 +5113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -5193,7 +5194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -6168,7 +6169,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -6273,7 +6274,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -6474,6 +6475,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -7263,7 +7270,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7282,7 +7289,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2 0.10.8",
- "syn 2.0.96",
+ "syn 2.0.97",
  "thiserror 1.0.69",
 ]
 
@@ -7323,7 +7330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7345,9 +7352,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "5dabd04e3b9a8c3c03d5e743f5ef5e1207befc9de704d477f7198cc28049763e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7389,7 +7396,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7480,6 +7487,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7505,7 +7523,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7516,7 +7534,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7641,7 +7659,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7839,7 +7857,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -7922,7 +7940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8010,6 +8028,12 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -8231,7 +8255,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
  "wasm-bindgen-shared",
 ]
 
@@ -8266,7 +8290,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8414,7 +8438,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8425,7 +8449,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8785,7 +8809,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
  "synstructure 0.13.1",
 ]
 
@@ -8816,7 +8840,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8827,7 +8851,7 @@ checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8847,7 +8871,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
  "synstructure 0.13.1",
 ]
 
@@ -8868,7 +8892,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]
@@ -8890,7 +8914,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.97",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = '0.9.5'
+version = '0.9.6'
 edition = "2021"
 authors = ["Glenn Gore <glenn@affinidi.com>"]
 description = "Affinidi Messaging"
@@ -22,9 +22,9 @@ license = "Apache-2.0"
 repository = "https://github.com/affinidi/affinidi-messaging"
 
 [workspace.dependencies]
-affinidi-messaging-sdk = { version = "0.9.5", path = "./affinidi-messaging-sdk" }
-affinidi-messaging-didcomm = { version = "0.9.5", path = "./affinidi-messaging-didcomm" }
-affinidi-messaging-mediator = { version = "0.9.5", path = "./affinidi-messaging-mediator" }
+affinidi-messaging-sdk = { version = "0.9.6", path = "./affinidi-messaging-sdk" }
+affinidi-messaging-didcomm = { version = "0.9.6", path = "./affinidi-messaging-didcomm" }
+affinidi-messaging-mediator = { version = "0.9.6", path = "./affinidi-messaging-mediator" }
 affinidi-did-resolver-cache-sdk = { version = "~0.2.8", features = ["network"] }
 anyhow = '1.0'
 askar-crypto = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 sha256 = "1.5"
 ssi = { version = "0.10" }
+textwrap = "0.16"
 thiserror = "2.0"
 time = "0.3"
 tokio = { version = "1.43", features = ["full"] }

--- a/affinidi-messaging-didcomm/src/message/pack_encrypted/mod.rs
+++ b/affinidi-messaging-didcomm/src/message/pack_encrypted/mod.rs
@@ -281,6 +281,9 @@ pub struct MessagingServiceMetadata {
 
     /// Service endpoint of used messaging service.
     pub service_endpoint: String,
+
+    /// Routing keys of used messaging service.
+    pub routing_keys: Vec<String>,
 }
 
 #[cfg(test)]

--- a/affinidi-messaging-didcomm/src/protocols/routing/mod.rs
+++ b/affinidi-messaging-didcomm/src/protocols/routing/mod.rs
@@ -414,6 +414,7 @@ pub(crate) async fn wrap_in_forward_if_needed(
     let messaging_service = MessagingServiceMetadata {
         id: services_chain.last().unwrap().0.clone(),
         service_endpoint: services_chain.first().unwrap().1.uri.clone(),
+        routing_keys,
     };
 
     Ok(Some((forward_msg, messaging_service)))

--- a/affinidi-messaging-mediator/src/messages/mod.rs
+++ b/affinidi-messaging-mediator/src/messages/mod.rs
@@ -43,6 +43,10 @@ impl MessageType {
             SDKMessageType::MessagePickupStatusRequest => {
                 message_pickup::status_request(message, state, session).await
             }
+            SDKMessageType::MessagePickupStatusResponse => Err(MediatorError::NotImplemented(
+                session.session_id.clone(),
+                "Mediator does not handle Message Pickup Status responses".into(),
+            )),
             SDKMessageType::MessagePickupDeliveryRequest => {
                 message_pickup::delivery_request(message, state, session).await
             }

--- a/affinidi-messaging-mediator/src/messages/store.rs
+++ b/affinidi-messaging-mediator/src/messages/store.rs
@@ -228,7 +228,7 @@ pub(crate) async fn store_forwarded_message(
     state: &SharedData,
     session: &Session,
     message: &str,
-    sender: &str,
+    sender: Option<&str>,
     recipient: &str,
 ) -> Result<(), MediatorError> {
     let _span = span!(tracing::Level::DEBUG, "store_forwarded_message",);
@@ -246,7 +246,7 @@ pub(crate) async fn store_forwarded_message(
 
         match state
             .database
-            .store_message(&session.session_id, message, recipient, Some(sender))
+            .store_message(&session.session_id, message, recipient, sender)
             .await
         {
             Ok(msg_id) => {

--- a/affinidi-messaging-sdk/src/lib.rs
+++ b/affinidi-messaging-sdk/src/lib.rs
@@ -37,6 +37,7 @@ mod resolvers;
 pub mod secrets;
 pub mod transports;
 
+#[derive(Clone)]
 pub struct ATM {
     pub(crate) inner: Arc<SharedState>,
 }

--- a/affinidi-messaging-sdk/src/messages/known.rs
+++ b/affinidi-messaging-sdk/src/messages/known.rs
@@ -12,6 +12,7 @@ pub enum MessageType {
     MediatorAccountManagement,       // Mediator Account Management Protocol
     MediatorACLManagement,           // Mediator Global ACL Management Protocol
     MessagePickupStatusRequest,      // Message Pickup 3.0 Status Request
+    MessagePickupStatusResponse,     // Message Pickup 3.0 Status Request
     MessagePickupDeliveryRequest,    // Message Pickup 3.0 Delivery Request
     MessagePickupMessagesReceived,   // Message Pickup 3.0 Messages Received (ok to delete)
     MessagePickupLiveDeliveryChange, // Message Pickup 3.0 Live-delivery-change (Streaming enabled)
@@ -38,6 +39,7 @@ impl FromStr for MessageType {
             "https://didcomm.org/messagepickup/3.0/status-request" => {
                 Ok(Self::MessagePickupStatusRequest)
             }
+            "https://didcomm.org/messagepickup/3.0/status" => Ok(Self::MessagePickupStatusResponse),
             "https://didcomm.org/messagepickup/3.0/live-delivery-change" => {
                 Ok(Self::MessagePickupLiveDeliveryChange)
             }

--- a/affinidi-messaging-sdk/src/messages/mod.rs
+++ b/affinidi-messaging-sdk/src/messages/mod.rs
@@ -128,14 +128,14 @@ pub struct GetMessagesResponse {
 impl GenericDataStruct for GetMessagesResponse {}
 
 /// Enum for the delete policy when retrieving messages
-/// Optimistic  - Deletes messages as they are fetched, occurs automatically within ATM
-/// OnReceive   - Will delete messages after they are received by the SDK
-/// DoNotDelete - Messages are not deleted (Default behavior)
-///               It is up to the caller as to when and how they want to delete messages
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub enum FetchDeletePolicy {
+    /// Optimistic  - Deletes messages as they are fetched, occurs automatically within ATM
     Optimistic,
+    /// OnReceive   - Will delete messages after they are received by the SDK
     OnReceive,
+    /// DoNotDelete - Messages are not deleted (Default behavior)
+    ///               It is up to the caller as to when and how they want to delete messages
     #[default]
     DoNotDelete,
 }

--- a/affinidi-messaging-sdk/src/profiles.rs
+++ b/affinidi-messaging-sdk/src/profiles.rs
@@ -356,6 +356,7 @@ impl ATM {
 
     /// Will create a websocket connection for the profile if one doesn't already exist
     /// Will return Ok() if a connection already exists, or if it successfully started a new connection
+    /// Automatically starts live_streaming
     pub async fn profile_enable_websocket(&self, profile: &Arc<Profile>) -> Result<(), ATMError> {
         let mediator = {
             let Some(mediator) = &*profile.inner.mediator else {

--- a/affinidi-messaging-sdk/src/profiles.rs
+++ b/affinidi-messaging-sdk/src/profiles.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     ATM,
 };
+use affinidi_messaging_didcomm::{Message, UnpackMetadata};
 use serde::{Deserialize, Serialize};
 use ssi::dids::{
     document::{service::Endpoint, Service},
@@ -99,7 +100,9 @@ pub struct ProfileInner {
     pub mediator: Arc<Option<Mediator>>,
     pub(crate) authorization: Mutex<Option<AuthorizationResponse>>,
     pub(crate) authenticated: AtomicBool,
+    /// Channel to send commands to the WS_Handler task
     pub(crate) channel_tx: Mutex<Sender<WsHandlerCommands>>,
+    /// Channel to receive commands from the WS_Handler task
     pub(crate) channel_rx: Mutex<Receiver<WsHandlerCommands>>,
 }
 
@@ -166,6 +169,56 @@ impl Profile {
             mediator.rest_endpoint.clone()
         } else {
             None
+        }
+    }
+
+    /// Sets up a direct channel to a provided MPSC Receiver
+    /// This will bypass the WS_Handler and send messages directly to the provided Receiver
+    pub async fn enable_direct_channel(
+        &self,
+        channel_tx: Sender<Box<(Message, UnpackMetadata)>>,
+    ) -> Result<(), ATMError> {
+        if let Some(mediator) = &*self.inner.mediator {
+            if let Some(channel) = &*mediator.ws_channel_tx.lock().await {
+                channel
+                    .send(WsConnectionCommands::EnableDirectChannel(channel_tx))
+                    .await
+                    .map_err(|err| {
+                        ATMError::TransportError(format!(
+                            "Could not send websocket message: {:?}",
+                            err
+                        ))
+                    })?;
+            }
+
+            Ok(())
+        } else {
+            Err(ATMError::TransportError(
+                "There is no mediator configured for this profile".to_string(),
+            ))
+        }
+    }
+
+    /// Disables the direct channel to the provided MPSC Receiver
+    pub async fn disable_direct_channel(&self) -> Result<(), ATMError> {
+        if let Some(mediator) = &*self.inner.mediator {
+            if let Some(channel) = &*mediator.ws_channel_tx.lock().await {
+                channel
+                    .send(WsConnectionCommands::DisableDirectChannel)
+                    .await
+                    .map_err(|err| {
+                        ATMError::TransportError(format!(
+                            "Could not send websocket message: {:?}",
+                            err
+                        ))
+                    })?;
+            }
+
+            Ok(())
+        } else {
+            Err(ATMError::TransportError(
+                "There is no mediator configured for this profile".to_string(),
+            ))
         }
     }
 }

--- a/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -247,30 +247,40 @@ impl MessagePickup {
                 })?;
             debug!("sent next request to ws_handler");
 
-            // Setup the timer for the wait, doesn't do anything till `await` is called in the select! macro
-            let sleep: tokio::time::Sleep = tokio::time::sleep(wait.unwrap_or_default());
-
             let stream = &mut atm.inner.ws_handler_recv_stream.lock().await;
-            select! {
-                _ = sleep, if wait.is_some() => {
-                    debug!("Timeout reached, no message received");
-                    Ok(None)
-                }
-                value = stream.recv() => {
-                    if let Some(msg) = value {
-                        match msg {
-                            WsHandlerCommands::MessageReceived(message, meta) => {
-                                Ok(Some((message, meta)))
-                            }
-                            _ => {
-                                Err(ATMError::MsgReceiveError("Unexpected message type".into()))
-                            }
-                        }
-                    } else {
+                // Setup the timer for the wait, doesn't do anything till `await` is called in the select! macro
+                let sleep: tokio::time::Sleep = tokio::time::sleep(wait.unwrap_or(Duration::MAX));
+                select! {
+                    _ = sleep, if wait.is_some() => {
+                        debug!("Timeout reached, no message received");
+                        atm.inner
+                .ws_handler_send_stream
+                .send(WsHandlerCommands::CancelNext)
+                .await
+                .map_err(|err| {
+                    ATMError::TransportError(format!(
+                        "Could not send message to ws_handler: {:?}",
+                        err
+                    ))
+                })?;
                         Ok(None)
                     }
+                    value = stream.recv() => {
+                        if let Some(msg) = value {
+                            match msg {
+                                WsHandlerCommands::MessageReceived(message, meta) => {
+                                    Ok(Some((message, meta)))
+                                }
+                                _ => {
+                                    Err(ATMError::MsgReceiveError(format!("Unexpected message type: {:#?}", msg)))
+                                }
+                            }
+                        } else {
+                            Ok(None)
+                        }
+                    }
                 }
-            }
+            
         }
         .instrument(_span)
         .await

--- a/affinidi-messaging-sdk/src/protocols/message_pickup.rs
+++ b/affinidi-messaging-sdk/src/protocols/message_pickup.rs
@@ -223,13 +223,13 @@ impl MessagePickup {
     /// Waits for the next message to be received via websocket live delivery
     /// atm  : The ATM SDK to use
     /// wait : How long to wait (in milliseconds) for a message before returning None
-    ///        If 0, will block forever until a message is received
+    ///        If None, will block forever until a message is received
     /// Returns a tuple of the message and metadata, or None if no message was received
     /// NOTE: You still need to delete the message from the server after receiving it
     pub async fn live_stream_next(
         &self,
         atm: &ATM,
-        wait: Duration,
+        wait: Option<Duration>,
     ) -> Result<Option<(Message, Box<UnpackMetadata>)>, ATMError> {
         let _span = span!(Level::DEBUG, "live_stream_next");
 
@@ -248,11 +248,11 @@ impl MessagePickup {
             debug!("sent next request to ws_handler");
 
             // Setup the timer for the wait, doesn't do anything till `await` is called in the select! macro
-            let sleep: tokio::time::Sleep = tokio::time::sleep(wait);
+            let sleep: tokio::time::Sleep = tokio::time::sleep(wait.unwrap_or_default());
 
             let stream = &mut atm.inner.ws_handler_recv_stream.lock().await;
             select! {
-                _ = sleep, if wait.as_millis() > 0 => {
+                _ = sleep, if wait.is_some() => {
                     debug!("Timeout reached, no message received");
                     Ok(None)
                 }

--- a/affinidi-messaging-text-client/Cargo.toml
+++ b/affinidi-messaging-text-client/Cargo.toml
@@ -35,6 +35,7 @@ tokio-stream.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 ratatui-image.workspace = true
+textwrap.workspace = true
 tui-logger.workspace = true
 tui-input.workspace = true
 uuid.workspace = true

--- a/affinidi-messaging-text-client/src/main.rs
+++ b/affinidi-messaging-text-client/src/main.rs
@@ -71,4 +71,6 @@ pub enum InputType {
     OurName,
     ChatMessage,
     AcceptInvite,
+    ManualConnectRemoteDID,
+    ManualConnectAlias,
 }

--- a/affinidi-messaging-text-client/src/state_store/actions/mod.rs
+++ b/affinidi-messaging-text-client/src/state_store/actions/mod.rs
@@ -20,7 +20,7 @@ pub enum Action {
     // Manual Connect
     ManualConnectPopupStart,
     ManualConnectPopupStop,
-    ManualConnect { remote_did: String },
+    ManualConnect { alias: String, remote_did: String },
     // Chat information
     ShowChatDetails { chat: String },
     CloseChatDetails,

--- a/affinidi-messaging-text-client/src/state_store/chat_message.rs
+++ b/affinidi-messaging-text-client/src/state_store/chat_message.rs
@@ -4,6 +4,7 @@ use ratatui::{
     text::Line,
 };
 use serde::{Deserialize, Serialize};
+use textwrap::Options;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum ChatEffect {
@@ -38,57 +39,70 @@ impl ChatMessage {
             timestamp: Local::now(),
         }
     }
-
-    pub fn render(&self) -> Line {
+    // (2025-02-01 20:17:27: << )
+    pub fn render(&self, width: usize) -> Vec<Line> {
+        let mut lines: Vec<Line> = Vec::new();
         match &self._type {
-            ChatMessageType::Inbound => Line::styled(
+            ChatMessageType::Inbound => {
+                let initial_indent = format!("{}: >> ", self.timestamp.format("%Y-%m-%d %H:%M:%S"));
+                let options = Options::new(width - 24)
+                    .initial_indent(&initial_indent)
+                    .subsequent_indent("                        ");
+
+                let l = textwrap::wrap(&self.message, options);
+                for line in l {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+
+                    lines.push(Line::styled(
+                        line.trim_end().to_string(),
+                        Style::default().fg(Color::Blue).bold(),
+                    ));
+                }
+            }
+            ChatMessageType::Outbound => lines.push(Line::styled(
                 format!(
                     "{}: << {}",
                     self.timestamp.format("%Y-%m-%d %H:%M:%S"),
                     self.message
                 ),
-                Style::default().fg(Color::Blue).bold(),
-            ),
-            ChatMessageType::Outbound => Line::styled(
-                format!(
-                    "{}: >> {}",
-                    self.timestamp.format("%Y-%m-%d %H:%M:%S"),
-                    self.message
-                ),
                 Style::default().italic().fg(Color::LightBlue),
-            ),
-            ChatMessageType::Error => Line::styled(
+            )),
+            ChatMessageType::Error => lines.push(Line::styled(
                 format!(
                     "{}: ERROR: {}",
                     self.timestamp.format("%Y-%m-%d %H:%M:%S"),
                     self.message
                 ),
                 Style::default().red(),
-            ),
+            )),
             ChatMessageType::Effect { effect } => match effect {
-                ChatEffect::Ballons => Line::styled(
+                ChatEffect::Ballons => lines.push(Line::styled(
                     format!(
                         "{}: << EFFECT:  You received some balloons!!! ",
                         self.timestamp.format("%Y-%m-%d %H:%M:%S")
                     ),
                     Style::default().fg(Color::LightGreen),
-                ),
-                ChatEffect::Confetti => Line::styled(
+                )),
+                ChatEffect::Confetti => lines.push(Line::styled(
                     format!(
                         "{}: << EFFECT:  You received some confetti!!! ",
                         self.timestamp.format("%Y-%m-%d %H:%M:%S")
                     ),
                     Style::default().fg(Color::LightGreen),
-                ),
-                ChatEffect::System => Line::styled(
+                )),
+                ChatEffect::System => lines.push(Line::styled(
                     format!(
                         "{}: System Message: {}",
                         self.timestamp.format("%Y-%m-%d %H:%M:%S"),
                         self.message
                     ),
                     Style::default().fg(Color::Yellow),
-                ),
+                )),
             },
         }
+
+        lines
     }
 }

--- a/affinidi-messaging-text-client/src/state_store/state.rs
+++ b/affinidi-messaging-text-client/src/state_store/state.rs
@@ -117,6 +117,8 @@ pub struct AcceptInvitePopupState {
 pub struct ManualConnectPopupState {
     pub show: bool,
     pub remote_did: String,
+    pub alias: String,
+    pub error_msg: Option<String>,
 }
 
 /// State holds the state of the application

--- a/affinidi-messaging-text-client/src/state_store/state_store.rs
+++ b/affinidi-messaging-text-client/src/state_store/state_store.rs
@@ -188,12 +188,17 @@ impl StateStore {
                     Action::ManualConnectPopupStop => {
                         state.manual_connect_popup.show = false;
                         state.manual_connect_popup.remote_did = String::new();
+                        state.manual_connect_popup.alias = String::new();
+                        state.manual_connect_popup.error_msg = None;
                     },
                     Action::ManualConnect { alias, remote_did } => {
                         match manual_connect_setup(&mut state, &atm, &alias, &remote_did).await {
                             Ok(_) => {
-                                // Everythign worked - close popup
+                                // Everything worked - close popup
                                 state.manual_connect_popup.show = false;
+                                state.manual_connect_popup.remote_did = String::new();
+                        state.manual_connect_popup.alias = String::new();
+                        state.manual_connect_popup.error_msg = None;
                             },
                             Err(e) => {
                                 state.manual_connect_popup.error_msg = Some(e.to_string());

--- a/affinidi-messaging-text-client/src/ui_management/pages/main_page/main_page.rs
+++ b/affinidi-messaging-text-client/src/ui_management/pages/main_page/main_page.rs
@@ -22,7 +22,6 @@ use ratatui::{
     Frame,
 };
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::warn;
 
 use super::{
     components::{
@@ -474,11 +473,7 @@ impl ComponentRender<()> for MainPage {
             vec![Line::from(NO_CHAT_SELECTED_MESSAGE)]
         };
         let message_offset = calculate_list_offset(chat_messages.height, messages.len());
-        warn!(
-            "Message Offset: {} messages: {}",
-            message_offset,
-            messages.len()
-        );
+
         let chat_message_window = Paragraph::new(messages)
             .block(Block::default().borders(Borders::ALL).title("Messages"))
             .wrap(Wrap { trim: false })

--- a/affinidi-messaging-text-client/src/ui_management/pages/main_page/main_page.rs
+++ b/affinidi-messaging-text-client/src/ui_management/pages/main_page/main_page.rs
@@ -22,6 +22,7 @@ use ratatui::{
     Frame,
 };
 use tokio::sync::mpsc::UnboundedSender;
+use tracing::warn;
 
 use super::{
     components::{
@@ -455,28 +456,35 @@ impl ComponentRender<()> for MainPage {
         );
         frame.render_widget(chat_description, chat_title);
 
-        // Chat Messages
         let messages = if let Some(active_chat) = self.props.chat_list.active_chat.as_ref() {
             self.get_chat_data(active_chat)
                 .map(|chat_data| {
-                    let message_offset =
-                        calculate_list_offset(chat_messages.height, chat_data.messages.len());
+                    // let message_offset =
+                    //   calculate_list_offset(chat_messages.height, chat_data.messages.len());
 
                     chat_data
                         .messages
                         .asc_iter()
-                        .skip(message_offset)
-                        .map(|mbi| ListItem::new(mbi.render()))
-                        .collect::<Vec<ListItem>>()
+                        // .skip(message_offset)
+                        .flat_map(|mbi| mbi.render(chat_messages.width as usize - 2))
+                        .collect::<Vec<Line>>()
                 })
                 .unwrap_or_default()
         } else {
-            vec![ListItem::new(Line::from(NO_CHAT_SELECTED_MESSAGE))]
+            vec![Line::from(NO_CHAT_SELECTED_MESSAGE)]
         };
+        let message_offset = calculate_list_offset(chat_messages.height, messages.len());
+        warn!(
+            "Message Offset: {} messages: {}",
+            message_offset,
+            messages.len()
+        );
+        let chat_message_window = Paragraph::new(messages)
+            .block(Block::default().borders(Borders::ALL).title("Messages"))
+            .wrap(Wrap { trim: false })
+            .scroll((message_offset as u16, 0));
 
-        let messages =
-            List::new(messages).block(Block::default().borders(Borders::ALL).title("Messages"));
-        frame.render_widget(messages, chat_messages);
+        frame.render_widget(chat_message_window, chat_messages);
 
         // Chat Message Input
         self.message_input_box.render(


### PR DESCRIPTION
## 3rd February 2025 (0.9.6)

### All (0.9.6)

* Cleaning up comments and documentation

### DIDComm Library (0.9.6)

* pack_encrypted will return the forwarded routing_keys from a Service Record
  * Useful for when detecting if message has already been wrapped in a forward/routing wrapper

### Mediator (0.9.6)

* Mediator can now handle JSON Object Attachments

### SDK (0.9.6)

* ATM Struct derives Clone trait, allowing for a simpler clone of the inner representation
* Message Pickup Protocol
  * FEATURE: live_stream_next() wraps Duration in an Option to be more clear that this is an optional setting
  * FIX: live_stream_next() properly waits now for next message vs. only fetching from cache
* Added the ability for a Profile to direct-stream received messages via a channel
  * Allows for mix and match combo when messages are being sent to the SDK
  * Application may want direct-receive capability (all messages from all profiles come on a single channel)
    * Use the WsHandler::DirectMode config option on ATM Configuration
  * Some Profiles may want cache mode where you can call next() against the cache. across all profiles
    * Default mode
  * You may have some tasks that want to stream via a dedicated channel on a per-profile basis
    * use profile.enable_direct_channel() and profile.disable_direct_channel()

### Text-Client (0.9.6)

* When sending a message, will detect if message is already wrapped in a forward envelope
* Chat Messages properly wrap in the text window making it easier to read.
