### PR TITLE
feat: log mediator_id

### DIFF
--- a/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::time::Duration;
 
 use affinidi_messaging_mediator_common::errors::MediatorError;
@@ -16,12 +17,18 @@ pub async fn statistics(database: Database) -> Result<(), MediatorError> {
 
         let mut previous_stats = MetadataStats::default();
 
+        let mediator_id = match env::var("MEDIATOR_ID") {
+            Ok(val) => val,
+            Err(_e) => "NA".to_string(),
+        };
+
         loop {
             interval.tick().await;
             let stats = database.get_db_metadata().await?;
             let delta = stats.delta(&previous_stats);
             info!(
                 event_type = "UpdateStats",
+                mediator_id = mediator_id,
                 received_bytes = stats.received_bytes,
                 sent_bytes = stats.sent_bytes,
                 deleted_bytes = stats.deleted_bytes,
@@ -38,6 +45,7 @@ pub async fn statistics(database: Database) -> Result<(), MediatorError> {
 
             info!(
                 event_type = "UpdateDeltaStats",
+                mediator_id = mediator_id,
                 received_bytes = delta.received_bytes,
                 sent_bytes = delta.sent_bytes,
                 deleted_bytes = delta.deleted_bytes,


### PR DESCRIPTION
I have added `mediator_id` into log lines for better observability. `mediator_id` is sourced from environment variable `MEDIATOR_ID` if exists. If not it is set to `NA`