### PR TITLE
feat: add mediator tags as config from environment and log in stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,11 +112,13 @@ tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
 tracing = { version = "0.1", features = [
     "max_level_debug",
     "release_max_level_info",
+    "valuable",
 ] }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "fmt",
     "json",
+    "valuable",
 ] }
 tracing-test = "0.2"
 tui-input = "0.11.0"

--- a/affinidi-messaging-mediator/.cargo/config.toml
+++ b/affinidi-messaging-mediator/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tracing_unstable"]        # needed for object logging

--- a/affinidi-messaging-mediator/src/server.rs
+++ b/affinidi-messaging-mediator/src/server.rs
@@ -88,8 +88,10 @@ pub async fn start() {
 
     // Start the statistics thread
     let _stats_database = database.clone(); // Clone the database handler for the statistics thread
+    let tags = config.tags.clone(); // Clone the tags config for the statistics thread
+
     tokio::spawn(async move {
-        statistics(_stats_database)
+        statistics(_stats_database, tags)
             .await
             .expect("Error starting statistics thread");
     });

--- a/affinidi-messaging-mediator/src/tasks/statistics.rs
+++ b/affinidi-messaging-mediator/src/tasks/statistics.rs
@@ -1,12 +1,16 @@
 use crate::database::{Database, stats::MetadataStats};
 use affinidi_messaging_mediator_common::errors::MediatorError;
-use std::env;
+use std::collections::HashMap;
 use std::time::Duration;
+use tracing::field::valuable;
 use tracing::{Instrument, Level, debug, info, span};
 
 /// Periodically logs statistics about the database.
 /// Is spawned as a task from main().
-pub async fn statistics(database: Database) -> Result<(), MediatorError> {
+pub async fn statistics(
+    database: Database,
+    tags: HashMap<String, String>,
+) -> Result<(), MediatorError> {
     let _span = span!(Level::INFO, "statistics");
 
     async move {
@@ -15,18 +19,13 @@ pub async fn statistics(database: Database) -> Result<(), MediatorError> {
 
         let mut previous_stats = MetadataStats::default();
 
-        let mediator_id = match env::var("MEDIATOR_ID") {
-            Ok(val) => val,
-            Err(_e) => "NA".to_string(),
-        };
-
         loop {
             interval.tick().await;
             let stats = database.get_db_metadata().await?;
             let delta = stats.delta(&previous_stats);
             info!(
                 event_type = "UpdateStats",
-                mediator_id = mediator_id,
+                tags = valuable(&tags),
                 received_bytes = stats.received_bytes,
                 sent_bytes = stats.sent_bytes,
                 deleted_bytes = stats.deleted_bytes,
@@ -43,7 +42,7 @@ pub async fn statistics(database: Database) -> Result<(), MediatorError> {
 
             info!(
                 event_type = "UpdateDeltaStats",
-                mediator_id = mediator_id,
+                tags = valuable(&tags),
                 received_bytes = delta.received_bytes,
                 sent_bytes = delta.sent_bytes,
                 deleted_bytes = delta.deleted_bytes,


### PR DESCRIPTION
This PR includes following:

- Add tags:HashMap<String,String> as a part of Config.
- Log tags as a part of statistics logging.
- Add cargo changes in dependencies and rustflags to enable object logging while using tracing